### PR TITLE
Migrate `ParVec`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: rust
+sudo: false
+script:
+    - cargo build
+    - cargo test
+    - cargo doc --no-deps
+after_success: |
+    [ $TRAVIS_BRANCH = master ] &&
+    [ $TRAVIS_PULL_REQUEST = false ] &&
+    bash deploy-docs.sh
+notifications:
+    webhooks: http://huon.me:54857/travis

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,10 +2,17 @@
 
 name = "par-vec"
 version = "0.0.1"
+license = "MIT/Apache-2.0"
+description = "A wrapper of `Vec` that provides safe, concurrent mutation of non-overlapping slices."
 authors = [
-	"Alexis <a.beingessner@gmail.com>", 
-	"Austin <austin.bonander@gmail.com>"
+	"Austin Bonander <austin.bonander@gmail.com>"
 ]
+
+repository = "https://github.com/contain-rs/par-vec"
+homepage = "https://github.com/contain-rs/par-vec"
+documentation = "https://contain-rs.github.io/par-vec/par-vec"
+keywords = ["data-structures", "parallel"]
+readme = "README.md"
 
 [dev-dependencies]
 rand = "*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,4 +2,11 @@
 
 name = "par-vec"
 version = "0.0.1"
-authors = ["Alexis <a.beingessner@gmail.com>"]
+authors = [
+	"Alexis <a.beingessner@gmail.com>", 
+	"Austin <austin.bonander@gmail.com>"
+]
+
+[dev-dependencies]
+rand = "*"
+threadpool = "*"

--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,0 +1,25 @@
+Copyright (c) 2015 The Rust Project Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+A wrapper of `Vec` that provides safe, concurrent mutation of nonoverlapping slices. Useful for parallel fork-join operations.

--- a/deploy-docs.sh
+++ b/deploy-docs.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -o errexit -o nounset
+
+rev=$(git rev-parse --short HEAD)
+
+cd target/doc
+
+git init
+git config user.email 'FlashCat@users.noreply.github.com'
+git config user.name 'FlashCat'
+git remote add upstream "https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git"
+git fetch upstream gh-pages
+git reset upstream/gh-pages
+
+touch .
+
+git add -A .
+git commit -m "rebuild pages at ${rev}"
+git push -q upstream HEAD:gh-pages

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,207 @@
-#[test]
-fn it_works() {
+#![feature(alloc)]
+#![cfg_attr(test, feature(test, step_by))]
+
+extern crate alloc;
+
+use self::alloc::arc;
+
+use std::cmp::min;
+use std::fmt::{Formatter, Debug};
+use std::fmt::Error as FmtError;
+use std::sync::Arc;
+use std::mem;
+use std::ops;
+
+/// A vector that can be operated on concurrently via non-overlapping slices.
+///
+/// Get a `ParVec` and a vector of slices via `new()`, send the slices to other threads
+/// and mutate them, then get the mutated vector with `into_inner()` when finished.
+pub struct ParVec<T> {
+    data: Arc<Vec<T>>,
 }
+
+impl<T: 'static + Send + Sync> ParVec<T> {
+    /// Create a new `ParVec`, returning it and a vector of slices that can be sent
+    /// to other threads and mutated concurrently.
+    pub fn new(vec: Vec<T>, slices: usize) -> (ParVec<T>, Vec<ParSlice<T>>) {
+        let data = Arc::new(vec);
+
+        let par_slices = sub_slices(&data[..], slices).into_iter()
+            .map(|slice|
+                ParSlice {
+                    _vec: data.clone(),
+                    data: unsafe { mem::transmute(slice) },
+                }
+            ).collect();
+
+        let par_vec = ParVec {
+            data: data,
+        };
+
+        (par_vec, par_slices)
+    }
+
+    /// Take the inner `Vec` if there are no slices remaining.
+    /// Returns `Err(self)` if there are still slices out there.
+    pub fn into_inner_opt(self) -> Result<Vec<T>, ParVec<T>> {
+        // Unwrap if we hold a unique reference
+        // (we don't use weak refs so ignore those)
+        if arc::strong_count(&self.data) == 1 {
+            let vec_ptr: &mut Vec<T> = unsafe { mem::transmute(&*self.data) };
+            Ok(mem::replace(vec_ptr, Vec::new()))
+        } else {
+            Err(self)
+        }
+    }
+
+    /// Take the inner `Vec`, waiting until all slices have been freed.
+    pub fn into_inner(mut self) -> Vec<T> {
+        loop {
+            match self.into_inner_opt() {
+                Ok(vec) => return vec,
+                Err(new_self) => self = new_self,
+            }
+        }
+    }
+}
+
+fn sub_slices<T>(parent: &[T], slice_count: usize) -> Vec<&[T]> {
+    let mut slices = Vec::new();
+
+    let len = parent.len();
+    let mut start = 0;
+
+    for curr in (1 .. slice_count + 1).rev() {
+        let slice_len = (len - start) / curr;
+        let end = min(start + slice_len, len);
+
+        slices.push(&parent[start..end]);
+        start += slice_len;
+    }
+
+    slices
+}
+
+/// A slice of `ParVec` that can be sent to another task for processing.
+/// Automatically releases the slice on drop.
+pub struct ParSlice<T: Send + 'static> {
+    // Just to keep the source vector alive while the slice is,
+    // since the ParVec can die asynchronously.
+    _vec: Arc<Vec<T>>,
+    // This isn't actually &'static but we're guarding it so it's safe.
+    data: &'static mut [T],
+}
+
+impl<T: Send> ops::Deref for ParSlice<T> {
+    type Target = [T];
+
+    fn deref<'a>(&'a self) -> &'a [T] {
+        self.data
+    }
+}
+
+impl<T: Send> ops::DerefMut for ParSlice<T> {
+    fn deref_mut<'a>(&'a mut self) -> &'a mut [T] {
+        self.data
+    }
+}
+
+impl<T: Send> Debug for ParSlice<T> where T: Debug {
+    fn fmt(&self, f: &mut Formatter) -> Result<(), FmtError> {
+        write!(f, "{:?}", self.data)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    extern crate rand;
+    extern crate threadpool;
+    extern crate test;
+
+    use super::ParVec;
+
+    use std::mem;
+
+    use self::rand::{thread_rng, Rng};
+    use self::test::Bencher;
+    use self::threadpool::ThreadPool;
+
+    const TEST_SLICES: usize = 8;
+    const TEST_MAX: u32 = 1000;
+
+    #[test]
+    fn test_unwrap_safely() {
+        let (vec, slices) = ParVec::new([5u32; TEST_MAX as usize].to_vec(), TEST_SLICES);
+        mem::drop(slices);
+
+        let vec = vec.into_inner();
+
+        assert_eq!(&*vec, &[5u32; TEST_MAX as usize][..]);
+    }
+
+    #[test]
+    fn test_slices() {
+        let (_, slices) = ParVec::new((1u32 .. TEST_MAX).collect(), TEST_SLICES);
+
+        assert_eq!(slices.len(), TEST_SLICES);
+    }
+
+    #[bench]
+    fn seq_prime_factors_1000(b: &mut Bencher) {
+        let vec: Vec<u32> = (1 .. TEST_MAX).collect();
+
+        b.iter(|| {
+            let _: Vec<(u32, Vec<u32>)> = vec.iter()
+                .map(|&x| (x, get_prime_factors(x)))
+                .collect();
+        });
+    }
+
+    #[bench]
+    fn par_prime_factors_1000(b: &mut Bencher) {
+        let mut rng = thread_rng();
+        let pool = ThreadPool::new(TEST_SLICES);
+
+        b.iter(|| {
+            let mut vec: Vec<(u32, Vec<u32>)> = (1 .. TEST_MAX)
+                .map(|x| (x, Vec::new())).collect();
+
+            // Shuffle so each thread gets an even distribution of work.
+            // Otherwise, the lower threads will quit early.
+            rng.shuffle(&mut *vec);
+
+            let (par_vec, par_slices) = ParVec::new(vec, TEST_SLICES);
+
+            for mut slice in par_slices.into_iter() {
+                pool.execute(move ||
+                    for pair in slice.iter_mut() {
+                        let (x, ref mut x_primes) = *pair;
+                        *x_primes = get_prime_factors(x);
+                    }
+                );
+            }
+
+            let mut vec = par_vec.into_inner();
+            // Sort so they're in the same order as sequential.
+            vec.sort();
+        });
+    }
+
+    fn get_prime_factors(x: u32) -> Vec<u32> {
+        (1 .. x).filter(|&y| x % y == 0 && is_prime(y)).collect()
+    }
+
+    fn is_prime(x: u32) -> bool {
+        if x < 3 { return true; }
+
+        if x & 1 == 0 { return false; }
+
+        for i in (3 .. x).step_by(2) {
+            if x % i == 0 { return false; }
+        }
+
+        true
+    }
+
+}
+


### PR DESCRIPTION
Tests and benchmarks run fine. No dependencies besides `std` and a few crates for convenience in the tests, which are only pulled in via the `dev-dependencies` class. Benchmarks look just as good as when I submitted the original PR.
