### PR TITLE
Remove `'static + Sync` bounds, API/documentation cleanup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,13 @@ documentation = "https://contain-rs.github.io/par-vec/par-vec"
 keywords = ["data-structures", "parallel"]
 readme = "README.md"
 
-[dev-dependencies]
-rand = "*"
-threadpool = "*"
+[features]
+bench = ["rand", "threadpool"]
+
+[dependencies.rand]
+version = "*"
+optional = true
+
+[dependencies.threadpool]
+version = "*"
+optional = true

--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 A wrapper of `Vec` that provides safe, concurrent mutation of nonoverlapping slices. Useful for parallel fork-join operations.
+
+###Note: Benchmarking
+As of June 2015, the benchmark APIs are only available with the nightly/unstable channel of Rust. Benchmarking has been placed behind a feature flag so this crate can still build and test on the stable channel.
+
+If you want to run benchmarks and have the Rust nightlies installed, use the following command:
+
+```
+cargo bench --features bench
+```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,6 +87,7 @@ fn sub_slices<T>(parent: &[T], slice_count: usize) -> Vec<RawSlice<T>> {
     use std::cmp;
     use std::raw::Repr;
 
+    let len = parent.len();
     let mut start = 0;
 
     // By iteratively dividing the length remaining in the vector by the number of slices


### PR DESCRIPTION
Closes #2.

Additionally, I took it upon myself to cleanup the crate a little, adding documentation where I thought it was needed and removing some unsafe code. 

I also renamed `into_inner` to `unwrap` because it suggests some work has to be done to get the inner value, whereas `into_inner` implies a simple destructuring.

Squash available upon request.

cc @Gankro, @huonw

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/contain-rs/par-vec/4)

<!-- Reviewable:end -->
